### PR TITLE
Add support "unsafe to use" endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.0.0
+  rev: v2.1.0
   hooks:
   - id: check-merge-conflict
   - id: trailing-whitespace
@@ -12,7 +12,7 @@ repos:
   - id: check-yaml
   - id: check-executables-have-shebangs
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.2.2
+  rev: v1.2.3
   hooks:
   - id: pretty-format-java
     args: [--autofix]
@@ -21,7 +21,7 @@ repos:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
 - repo: https://github.com/Yelp/detect-secrets
-  rev: v0.11.3
+  rev: v0.12.0
   hooks:
   - id: detect-secrets
     args: [--baseline, .secrets.baseline]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,9 @@
 {
-  "exclude_regex": null,
-  "generated_at": "2019-01-28T12:41:36Z",
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2019-02-14T20:34:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -32,5 +35,5 @@
       }
     ]
   },
-  "version": "0.11.3"
+  "version": "0.12.0"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .PHONY: install-hooks
 
+.git/hooks/pre-commit: venv
+	${CURDIR}/venv/bin/pre-commit install --install-hooks
+
+install-hooks: .git/hooks/pre-commit
+	@true
+
 venv:
 	virtualenv venv
 	./venv/bin/pip install pre-commit
-
-install-hooks: venv
-	./venv/bin/pre-commit install --install-hooks

--- a/plugin/src/main/resources/kotlin/retrofit2/api.mustache
+++ b/plugin/src/main/resources/kotlin/retrofit2/api.mustache
@@ -37,8 +37,13 @@ interface {{classname}} {
   @Headers({{#vendorExtensions.x-operation-id}}{{{newline}}}    "X-Operation-ID: {{vendorExtensions.x-operation-id}}"{{/vendorExtensions.x-operation-id}}{{^formParams}}{{#prioritizedContentTypes}}{{#-first}},
     "Content-Type:{{{mediaType}}}"{{/-first}}{{/prioritizedContentTypes}}{{/formParams}}
   )
-  @{{httpMethod}}("{{{path}}}"){{#isDeprecated}}
-  @Deprecated(message = "Deprecated"){{/isDeprecated}}
+
+  @{{httpMethod}}("{{{path}}}"){{#vendorExtensions.x-unsafe-operation}}{{#isDeprecated}}
+      @Deprecated(message = "Deprecated and unsafe to use"){{/isDeprecated}}{{^isDeprecated}}
+      @Deprecated(message = "Unsafe to use"){{/isDeprecated}}
+  {{/vendorExtensions.x-unsafe-operation}}{{^vendorExtensions.x-unsafe-operation}}{{#isDeprecated}}
+      @Deprecated(message = "Deprecated"){{/isDeprecated}}
+  {{/vendorExtensions.x-unsafe-operation}}
   fun {{operationId}}({{^allParams}}){{/allParams}}
     {{#allParams}}{{>retrofit2/queryParams}}{{>retrofit2/pathParams}}{{>retrofit2/headerParams}}{{>retrofit2/bodyParams}}{{>retrofit2/formParams}}{{#hasMore}},
     {{/hasMore}}{{^hasMore}}


### PR DESCRIPTION
This PR exposes one of the internally developed features to ensure that endpoints that are _not good enough_ to be "blindly" used from users of the generated code.

All the endpoints that are annotated with ``x-unsafe-operation`` will be annotated with a deprecation warning.

The unsafe operations could be defined with two different approaches:
 * in ``#/info/x-operation-ids-unsafe-to-use`` as a list of operation ids
 * on the operation object itself with ``x-unsafe-operation: true``

@cortinico : Could you please review this and give me info on where to write to write tests and documentation