### PR TITLE
Fix model sanitisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .*
-local.properties
-venv/
 build/
+java_pid*.hprof
+local.properties
 out/
+venv/

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     implementation("com.google.guava:guava:27.0-jre")
     implementation("io.swagger:swagger-codegen:2.3.1")
     implementation("org.json:json:20180813")
+
+    testImplementation("junit:junit:4.12")
 }
 
 tasks.register<Jar>("sourcesJar") {

--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -319,7 +319,7 @@ class KotlinGenerator : SharedCodegen() {
             name
         } else {
             matchXModel(name)
-                    .split(".").last()
+                    .replace(Regex("(\\.|\\s)"), "_")
                     .toPascalCase()
                     .sanitizeKotlinSpecificNames(specialCharReplacements)
                     .apply { escapeReservedWord(this) }

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -1,0 +1,9 @@
+package com.yelp.codegen
+
+import org.junit.Test
+
+class KotlinGeneratorTest {
+
+    @Test
+    fun dummyTest() {}
+}

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -5,5 +5,11 @@ import org.junit.Test
 class KotlinGeneratorTest {
 
     @Test
-    fun dummyTest() {}
+    fun test_toModelName_does_not_trim_too_much() {
+        assert(KotlinGenerator().toModelName("model") == "Model")
+        assert(KotlinGenerator().toModelName("model with space") == "ModelWithSpace")
+        assert(KotlinGenerator().toModelName("model with dot.s") == "ModelWithDotS")
+        assert(KotlinGenerator().toModelName("model with userscore_s") == "ModelWithUserscoreS")
+    }
+
 }

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -5,11 +5,10 @@ import org.junit.Test
 class KotlinGeneratorTest {
 
     @Test
-    fun test_toModelName_does_not_trim_too_much() {
+    fun toModelName_doesNotTrimTooMuch() {
         assert(KotlinGenerator().toModelName("model") == "Model")
         assert(KotlinGenerator().toModelName("model with space") == "ModelWithSpace")
         assert(KotlinGenerator().toModelName("model with dot.s") == "ModelWithDotS")
         assert(KotlinGenerator().toModelName("model with userscore_s") == "ModelWithUserscoreS")
     }
-
 }


### PR DESCRIPTION
The goal of this PR is to address a problem, discovered internally, related to the _too aggressive_ approach during sanitisation.

Model named as "model with spaces" or "model.with.dots" could lead to inconsistent names.
The updated approach does avoid the split of the model name but instead does replace the "bad" characters with something (an underscore) that will force a valid PascalCase representation and will be removed by `sanitizeKotlinSpecificNames` call.

---
Internally we had something similar to
```yaml
... # this is only a snipped of the specs
definitions:
  a:
    type: object
    x-model: a
  wrapper:
    a:
      additionalProperties:
        $ref: '#/definitions/a'
      type: object
      x-model: wrapper.a
```
Without the fix the generated code ignores the fact that `#/definitions/wrapper/properties/a` should be a `Map<String, A>` and it generates as `A` and this is *bad* as it changes the semantic of the endpoint and potentially makes parsing the response crashing as incompatible.

With the fix the generated code for `#/definitions/wrapper/properties/a` will be `WrapperA` (a type alias to `Map<String, A>`) which is what we would expect.