### PR TITLE
Ensure that retrofit body is not nullable

### DIFF
--- a/plugin/src/main/resources/kotlin/retrofit2/bodyParams.mustache
+++ b/plugin/src/main/resources/kotlin/retrofit2/bodyParams.mustache
@@ -1,1 +1,1 @@
-{{#isBodyParam}}@retrofit2.http.Body  {{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{/isBodyParam}}
+{{#isBodyParam}}@retrofit2.http.Body  {{paramName}}: {{{dataType}}}{{/isBodyParam}}


### PR DESCRIPTION
During some internal use of the plugin we did noticed that specs that allow a body parameter to be optional are converted to something similar to
```kotlin
  @Headers(
    "X-Operation-ID: operation_id"
  )
  @POST("/path")
  fun postBodyOptional(
    @retrofit2.http.Body  myBodyProp: MyBodyProp?
  ): Single<XnullableTypeResponses>
```
Due to some retrofit limitation/design choices it's not possible to pass `null` as body (retrofit will have issues on determining the content-type). More information are available on https://github.com/square/retrofit/issues/1488

There are multiple possible approaches to address this issues on the codegen and few of them require some code duplication.

The objective of this PR is _just_ to make sure that the body will not marked as nullable, so we're basically ignoring the fact that body is an optional parameter.
