### PR TITLE
Update SharedCodegen to fallback to title usage if x-model is not present

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -122,10 +122,14 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
     }
 
     /**
-     * Returns the x-model alternative name if it was defined
+     * Returns the x-model alternative name if it was defined.
+     * If the x-model alternative name is not found then the call will
+     * use the defined title, if any, or returns the input name
      */
     fun matchXModel(name: String): String {
-        return xModelMatches[name] ?: name
+        return xModelMatches[name] ?: (
+            this.swagger?.definitions?.get(name)?.title ?: name
+        )
     }
 
     /**


### PR DESCRIPTION
The current plugin does use `x-model` field for model name determination.

According to the swagger specification `title` should be used to define the _model name_.
Internally, in Yelp, we heavily use `x-model` custom vendor extension to be able to define names also for objects that do not allow the presence of title.

The goal of this PR is to ensure that `title` is honoured if present and used as fallback in case `x-model` is not present.

Let's get the following specs
```yaml
swagger: "2.0",
info: {
  title: Test
  version: 1.0.0
paths: {},
definitions:
  def1:
    type: object
  def2:
    type: object
    x-model: model2
  def3:
    title: title3
    type: object
  def4:
    title: title4
    type: object
    x-model: model4
```
Before this PR the generated models would be:
 * `def1` for `#/definitions/def1`
 * `model2` for `#/definitions/def2`
 * `def3` for `#/definitions/def3`
 * `model4` for `#/definitions/def4`
After this PR the generated models would be:
 * `def1` for `#/definitions/def1`
 * `model2` for `#/definitions/def2`
 * `title3` for `#/definitions/def3`  _**DIFFERENT**_
 * `model4` for `#/definitions/def4`
