### PR TITLE
Read spec version from swagger spec via codegen tools

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     implementation("commons-cli:commons-cli:1.4")
     implementation("com.google.guava:guava:27.0-jre")
     implementation("io.swagger:swagger-codegen:2.3.1")
-    implementation("org.json:json:20180813")
 
     testImplementation("junit:junit:4.12")
 }

--- a/plugin/src/main/java/com/yelp/codegen/plugin/CodegenPlugin.kt
+++ b/plugin/src/main/java/com/yelp/codegen/plugin/CodegenPlugin.kt
@@ -130,8 +130,8 @@ open class GenerateTask : DefaultTask() {
                 version
             }
             else -> {
-                println("Issue in reading version from Swagger Spec file. Falling back to 0.0.0")
-                "0.0.0"
+                println("Issue in reading version from Swagger Spec file. Falling back to $DEFAULT_VERSION")
+                DEFAULT_VERSION
             }
         }
     }


### PR DESCRIPTION
The idea of this PR is to ensure that version extraction from swagger specs supports YAML format too.

In order to avoid adding a new dependency (`org.yaml.snakeyaml`) and manually reading the file I've opted to delegate the parsing process to `SwaggerParser` provided by swagger-codegen.

NOTE: The check in `readVersionFromSpecfile` is not needed in case the specs are valid as `#/info/version` is required. As we don't revalidate the specs adding the check gives us the flexibility of supporting slightly invalid specs as well