### PR TITLE
Fix multi part issue

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -374,9 +374,7 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
      * Determine if the swagger operation consumes mutipart content.
      */
     private fun isMultipartOperation(operation: Operation?): Boolean {
-        return operation?.consumes != null && operation.consumes.any {
-            consume -> consume == "multipart/form-data"
-        }
+        return operation?.consumes?.any { it == "multipart/form-data" } ?: false
     }
 
     /**

--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -206,7 +206,7 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
 
     /**
      * Private method to investigate all the properties of a models, filter only the [RefProperty] and eventually
-     * propagate the `x-nullable` vendor config.
+     * propagate the `x-nullable` vendor extension.
      */
     private fun propagateXNullableToProperties(model: Model, allDefinitions: MutableMap<String, Model>) {
         model.properties
@@ -216,7 +216,7 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
     }
 
     /**
-     * Private method to propagate the `x-nullable` vendor config form the global definitions to the usage.
+     * Private method to propagate the `x-nullable` vendor extension form the global definitions to the usage.
      */
     private fun propagateXNullableVendorExtension(
         refProperty: RefProperty,

--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -371,6 +371,15 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
     }
 
     /**
+     * Determine if the swagger operation consumes mutipart content.
+     */
+    private fun isMultipartOperation(operation: Operation?): Boolean {
+        return operation?.consumes != null && operation.consumes.any {
+            consume -> consume == "multipart/form-data"
+        }
+    }
+
+    /**
      * Convert Swagger Operation object to Codegen Operation object
      *
      * The function takes care of adding additional vendor extensions on the Codegen Operation
@@ -393,6 +402,7 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
         if (unsafeOperations.contains(operation?.operationId)) {
             codegenOperation.vendorExtensions[X_UNSAFE_OPERATION] = true
         }
+        codegenOperation.isMultipart = isMultipartOperation(operation)
         return codegenOperation
     }
 


### PR DESCRIPTION
The goal of this PR is to address an issue related to file uploads.
The issue was identified internally and ticketed on COREMOBAPI-1461

The issue could be summarised as: _we're generating incorrect code in case of file parameters_

Assuming a simple endpoint
```json
"/send/file": {
    "post": {
        "consumes": ["multipart/form-data"],
        "parameters": [
            {
                "in": "formData",
                "type": "file",
                "name": "file",
                "required": true
            }
        ],
        "responses": {
            "200": {
                "description": "fafa"
            }
        }
    }
}
```

The generated code should look like
```kotlin
@JvmSuppressWildcards
interface DefaultApi {
  @retrofit2.http.Multipart    // <- different
  @Headers(
    "X-Operation-ID: "
  )
  @POST("/send/file")
  fun sendFilePost(
    @retrofit2.http.Part(    // <- different
      "file\"; filename=\"file") file:  RequestBody): Completable
}
```
while the following code is the currently generated content
```kotlin
@JvmSuppressWildcards
interface DefaultApi {
  @retrofit2.http.FormUrlEncoded
  @Headers(
    "X-Operation-ID: "
  )
  @POST("/send/file")
  fun sendFilePost(@retrofit2.http.Field("file\"; filename=\"file") file:  RequestBody): Completable
}
```

The issue is caused by the fact that swagger-codegen does not keep in consideration the operation level `consumes` key to properly set `isMultipart` attribute of `Operation` object.
