### PR TITLE
Extend visibility of Custom Moshi Adapters

### DIFF
--- a/plugin/src/main/resources/kotlin/tools/TypesAdapters.kt.mustache
+++ b/plugin/src/main/resources/kotlin/tools/TypesAdapters.kt.mustache
@@ -18,7 +18,7 @@ import java.math.BigDecimal
  * Moshi Factory to handle all the custom types we want to support,
  * such as [LocalDate], [ZonedDateTime], [BigDecimal].
  */
-internal class TypesAdapterFactory : JsonAdapter.Factory {
+class TypesAdapterFactory : JsonAdapter.Factory {
     private val types = mapOf<Type, JsonAdapter<*>>(
             LocalDate::class.java to LocalDateAdapter(),
             ZonedDateTime::class.java to ZonedDateTimeAdapter(),

--- a/plugin/src/main/resources/kotlin/tools/XNullableAdapterFactory.kt.mustache
+++ b/plugin/src/main/resources/kotlin/tools/XNullableAdapterFactory.kt.mustache
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import java.lang.reflect.Type
 
-internal class XNullableAdapterFactory : JsonAdapter.Factory {
+class XNullableAdapterFactory : JsonAdapter.Factory {
     override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
         if (annotations.any { it is XNullable }) {
             return object : JsonAdapter<Any>() {


### PR DESCRIPTION
I'm extending the visibility of the custom Moshi Adapters `TypesAdapterFactory` and `XNullableAdapterFactory` from internal to public. This will support the use case of developers that want to initialise their own Moshi instance and want to provide custom Type adapters on top of the generated ones.

Fore more context see the doc [here](
https://github.com/Yelp/swagger-gradle-codegen/blob/master/plugin/src/main/resources/kotlin/tools/GeneratedCodeConverters.kt.mustache#L17)
```
    /**
     * Creates everything needed for retrofit to make it work with the client lib, including a
     * [Moshi] instance. If you want to use your own instance of moshi, use
     * converterFactory(moshi) instead, and add [XNullableAdapterFactory], [KotlinJsonAdapterFactory] and
     * [TypesAdapterFactory] to your moshi builder (in a similar way how we are instantiating the `moshi` field here).
     */
```