### PR TITLE
Prepare Release v1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,21 @@
+# swagger-gradle-codegen Release Notes
+
+Here you can find the release notes for this project. Please note that list of releases is available also in the [releases](https://github.com/Yelp/swagger-gradle-codegen/releases) page on Github.
+
+## v1.1.0 (2019-06-05)
+
+* [FEATURE] Add support "unsafe to use" endpoints (#18)
+* [FEATURE] Update SharedCodegen to fallback to title usage if x-model is not present (#21)
+* [FEATURE] Add support for composed models and reference models (#22)
+* [FEATURE] Extended visibility of Custom Moshi Adapters (#30)
+* [BUGFIX] Fix model sanitisation (#19)
+* [BUGFIX] Ensure that retrofit body is not nullable (#20)
+* [BUGFIX] Read spec version from SwaggerSpec via codegen tools and allow to set `DEFAULT_VERSION` constant (#23)
+* [BUGFIX] Fix issue with MultiPart request and file uploads (#26)
+* [BUGFIX] Fix for square brackets in the operation name (#32)
+
+Thanks to @cortinico, @MatthewTPage, @GuilhE, @macisamuele and @redwarp for the support with this release.
+
+## v1.0.0 (2019-01-04)
+
+* Initial Release of swagger-gradle-codegen

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,18 +4,28 @@ Here you can find the release notes for this project. Please note that list of r
 
 ## v1.1.0 (2019-06-05)
 
-* [FEATURE] Add support "unsafe to use" endpoints (#18)
-* [FEATURE] Update SharedCodegen to fallback to title usage if x-model is not present (#21)
-* [FEATURE] Add support for composed models and reference models (#22)
-* [FEATURE] Extended visibility of Custom Moshi Adapters (#30)
-* [BUGFIX] Fix model sanitisation (#19)
-* [BUGFIX] Ensure that retrofit body is not nullable (#20)
-* [BUGFIX] Read spec version from SwaggerSpec via codegen tools and allow to set `DEFAULT_VERSION` constant (#23)
-* [BUGFIX] Fix issue with MultiPart request and file uploads (#26)
-* [BUGFIX] Fix for square brackets in the operation name (#32)
+* 🎁 Update SharedCodegen to fallback to title usage if x-model is not present [#21]
+* 🎁 Add support for composed models and reference models [#22]
+* 🎁 Extended visibility of Custom Moshi Adapters [#30]
+* 🐛 Fix model sanitisation [#19]
+* 🐛 Ensure that retrofit body is not nullable [#20]
+* 🐛 Read spec version from SwaggerSpec via codegen tools and allow to set `DEFAULT_VERSION` constant [#23]
+* 🐛 Fix issue with MultiPart request and file uploads [#26]
+* 🐛 Fix for square brackets in the operation name [#32]
 
 Thanks to @cortinico, @MatthewTPage, @GuilhE, @macisamuele and @redwarp for the support with this release.
 
 ## v1.0.0 (2019-01-04)
 
 * Initial Release of swagger-gradle-codegen
+
+### Link Section
+
+[#19]: https://github.com/Yelp/swagger-gradle-codegen/pull/19/
+[#20]: https://github.com/Yelp/swagger-gradle-codegen/pull/20/
+[#21]: https://github.com/Yelp/swagger-gradle-codegen/pull/21/
+[#22]: https://github.com/Yelp/swagger-gradle-codegen/pull/22/
+[#23]: https://github.com/Yelp/swagger-gradle-codegen/pull/23/
+[#26]: https://github.com/Yelp/swagger-gradle-codegen/pull/26/
+[#30]: https://github.com/Yelp/swagger-gradle-codegen/pull/30/
+[#32]: https://github.com/Yelp/swagger-gradle-codegen/pull/32/

--- a/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
+++ b/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
@@ -1,7 +1,7 @@
 @file:Suppress("Unused")
 
 object PublishingVersions {
-    const val PLUGIN_VERSION = "1.1.0-SNAPSHOT"
+    const val PLUGIN_VERSION = "1.1.0"
     const val PLUGIN_GROUP = "com.yelp.codegen"
     const val PLUGIN_ARTIFACT = "plugin"
 }

--- a/samples/generated-code/build.gradle
+++ b/samples/generated-code/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.4.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
-        classpath "com.yelp.codegen:plugin:1.0.0"
+        classpath "com.yelp.codegen:plugin:1.1.0"
     }
 }
 

--- a/samples/groovy-android/build.gradle
+++ b/samples/groovy-android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.4.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
-        classpath "com.yelp.codegen:plugin:1.0.0"
+        classpath "com.yelp.codegen:plugin:1.1.0"
     }
 }
 

--- a/samples/kotlin-android/build.gradle.kts
+++ b/samples/kotlin-android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library") version "3.4.1"
     kotlin("android") version "1.3.31"
-    id("com.yelp.codegen.plugin") version "1.0.0"
+    id("com.yelp.codegen.plugin") version "1.1.0"
 }
 
 android {


### PR DESCRIPTION
Let's bump the version to `1.1.0` stable.

Moreover I've also started a CHANGES.md file to keep track of the
release notes. I'm going to copy those release notes inside the [releases](https://github.com/Yelp/swagger-gradle-codegen/releases) page on GitHub.