### PR TITLE
Remove leading slash if Swagger Spec are specifying a basePath

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -33,7 +33,7 @@ class KotlinGenerator : SharedCodegen() {
 
     private val apiDocPath = "docs/"
     private val modelDocPath = "docs/"
-    private var basePath: String? = null
+    internal var basePath: String? = null
 
     private val retrofitImport = mapOf(
             "GET" to "retrofit2.http.GET",

--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -33,6 +33,7 @@ class KotlinGenerator : SharedCodegen() {
 
     private val apiDocPath = "docs/"
     private val modelDocPath = "docs/"
+    private var basePath: String? = null
 
     private val retrofitImport = mapOf(
             "GET" to "retrofit2.http.GET",
@@ -407,6 +408,11 @@ class KotlinGenerator : SharedCodegen() {
         getHeadersToIgnore().forEach { headerName ->
             ignoreHeaderParameter(headerName, codegenOperation)
         }
+
+        // Let's remove the leading
+        if (!basePath.isNullOrBlank()) {
+            codegenOperation.path = codegenOperation.path.removePrefix("/")
+        }
         return codegenOperation
     }
 
@@ -432,6 +438,7 @@ class KotlinGenerator : SharedCodegen() {
 
         // Override the swagger version with the one provided from command line.
         swagger.info.version = additionalProperties[SPEC_VERSION] as String
+        this.basePath = swagger.basePath
     }
 
     /**

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -3,6 +3,7 @@ package com.yelp.codegen
 import io.swagger.codegen.CodegenModel
 import io.swagger.codegen.CodegenProperty
 import io.swagger.models.Info
+import io.swagger.models.Operation
 import io.swagger.models.Swagger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -315,6 +316,30 @@ class KotlinGeneratorTest {
     }
 
     @Test
+    fun fromOperation_withBasePath_removeLeadingSlash() {
+        val generator = KotlinGenerator()
+        generator.basePath = "/v2"
+        val operation = Operation()
+        val swagger = Swagger()
+
+        val codegenOperation = generator.fromOperation("/helloworld", "GET", operation, mutableMapOf(), swagger)
+
+        assertEquals("helloworld", codegenOperation.path)
+    }
+
+    @Test
+    fun fromOperation_withNoBasePath_leadingSlashIsNotRemoved() {
+        val generator = KotlinGenerator()
+        generator.basePath = null
+        val operation = Operation()
+        val swagger = Swagger()
+
+        val codegenOperation = generator.fromOperation("/helloworld", "GET", operation, mutableMapOf(), swagger)
+
+        assertEquals("/helloworld", codegenOperation.path)
+    }
+
+    @Test
     fun preprocessSwagger() {
         val generator = KotlinGenerator()
         generator.additionalProperties()[SPEC_VERSION] = "42.0.0"
@@ -322,8 +347,10 @@ class KotlinGeneratorTest {
         val swagger = Swagger()
         swagger.info = Info()
         swagger.info.version = "1.0.0"
+        swagger.basePath = "/v2"
         generator.preprocessSwagger(swagger)
 
         assertEquals("42.0.0", swagger.info.version)
+        assertEquals("/v2", generator.basePath)
     }
 }


### PR DESCRIPTION
When generating Retrofit interfaces, we need to remove the leading
slash from the generated path. Having a leading slash will force
the path to be absolute for the host and will make URLs like:
https://petstore.swagger.io/v2/
impossible to call.

Fixes #49