### PR TITLE
Fix handling of Top Level Operation Headers

### DIFF
--- a/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
+++ b/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
@@ -1,7 +1,7 @@
 @file:Suppress("Unused")
 
 object PublishingVersions {
-    const val PLUGIN_VERSION = "1.1.1"
+    const val PLUGIN_VERSION = "1.2.0-SNAPSHOT"
     const val PLUGIN_GROUP = "com.yelp.codegen"
     const val PLUGIN_ARTIFACT = "plugin"
 }

--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -32,10 +32,15 @@ const val ARTIFACT_ID = "artifact_id"
 const val GROUP_ID = "group_id"
 const val HEADERS_TO_IGNORE = "headers_to_ignore"
 
+// Vendor Extensions Names
 internal const val X_NULLABLE = "x-nullable"
 internal const val X_MODEL = "x-model"
 internal const val X_OPERATION_ID = "x-operation-id"
 internal const val X_UNSAFE_OPERATION = "x-unsafe-operation"
+
+// Headers Names
+internal const val HEADER_X_OPERATION_ID = "X-Operation-Id"
+internal const val HEADER_CONTENT_TYPE = "Content-Type"
 
 abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
 

--- a/plugin/src/main/resources/kotlin/retrofit2/api.mustache
+++ b/plugin/src/main/resources/kotlin/retrofit2/api.mustache
@@ -25,19 +25,12 @@ interface {{classname}} {
   {{#isMultipart}}@retrofit2.http.Multipart{{/isMultipart}}{{^isMultipart}}@retrofit2.http.FormUrlEncoded{{/isMultipart}}
   {{/-first}}
   {{/formParams}}
-  {{^formParams}}
-  {{#prioritizedContentTypes}}
-  {{#-first}}
-  @Headers({
-    "Content-Type:{{{mediaType}}}"
-  })
-  {{/-first}}
-  {{/prioritizedContentTypes}}
-  {{/formParams}}
-  @Headers({{#vendorExtensions.x-operation-id}}{{{newline}}}    "X-Operation-ID: {{vendorExtensions.x-operation-id}}"{{/vendorExtensions.x-operation-id}}{{^formParams}}{{#prioritizedContentTypes}}{{#-first}},
-    "Content-Type:{{{mediaType}}}"{{/-first}}{{/prioritizedContentTypes}}{{/formParams}}
-  )
-
+  {{#vendorExtensions.hasOperationHeaders}}
+  @Headers(
+    {{#vendorExtensions.operationHeaders}}"{{first}}: {{second}}"{{^-last}},
+    {{/-last}}{{#-last}}
+  ){{/-last}}{{/vendorExtensions.operationHeaders}}
+  {{/vendorExtensions.hasOperationHeaders}}
   @{{httpMethod}}("{{{path}}}"){{#vendorExtensions.x-unsafe-operation}}{{#isDeprecated}}
       @Deprecated(message = "Deprecated and unsafe to use"){{/isDeprecated}}{{^isDeprecated}}
       @Deprecated(message = "Unsafe to use"){{/isDeprecated}}

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -1,6 +1,7 @@
 package com.yelp.codegen
 
 import io.swagger.codegen.CodegenModel
+import io.swagger.codegen.CodegenOperation
 import io.swagger.codegen.CodegenProperty
 import io.swagger.models.Info
 import io.swagger.models.Operation
@@ -352,5 +353,15 @@ class KotlinGeneratorTest {
 
         assertEquals("42.0.0", swagger.info.version)
         assertEquals("/v2", generator.basePath)
+    }
+
+    @Test
+    fun processTopLevelHeaders_withNoHeaders() {
+        val generator = KotlinGenerator()
+        val operation = CodegenOperation()
+
+        generator.processTopLevelHeaders(operation)
+
+        assertEquals(false, operation.vendorExtensions["hasOperationHeaders"])
     }
 }

--- a/samples/generated-code/build.gradle
+++ b/samples/generated-code/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.4.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
-        classpath "com.yelp.codegen:plugin:1.1.1"
+        classpath "com.yelp.codegen:plugin:1.2.0-SNAPSHOT"
     }
 }
 

--- a/samples/groovy-android/build.gradle
+++ b/samples/groovy-android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.4.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
-        classpath "com.yelp.codegen:plugin:1.1.1"
+        classpath "com.yelp.codegen:plugin:1.2.0-SNAPSHOT"
     }
 }
 

--- a/samples/junit-tests/build.gradle
+++ b/samples/junit-tests/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.4.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
-        classpath "com.yelp.codegen:plugin:1.1.1"
+        classpath "com.yelp.codegen:plugin:1.2.0-SNAPSHOT"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16"
     }
 }

--- a/samples/kotlin-android/build.gradle.kts
+++ b/samples/kotlin-android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library") version "3.4.2"
     kotlin("android") version "1.3.41"
-    id("com.yelp.codegen.plugin") version "1.1.1"
+    id("com.yelp.codegen.plugin") version "1.2.0-SNAPSHOT"
 }
 
 android {


### PR DESCRIPTION
This PR cleans up the mustache template responsible of handling the generation of top level Retrofit headers.

Headers are now generated inside the KotlinGenerator class and passed to the template as a list of pair. This makes the handling of 0, 1, more header scenarios easier both on the generator and on the mustache template.

JUnit tests are attached.

Fixes #45 