### PR TITLE
Allow dot in parameter names for operations (#73)

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -453,7 +453,7 @@ class KotlinGenerator : SharedCodegen() {
      * parameter name generation.
      */
     override fun removeNonNameElementToCamelCase(name: String?): String {
-        return super.removeNonNameElementToCamelCase(name, "[-_:;#\\[\\]]")
+        return super.removeNonNameElementToCamelCase(name, "[-_:;.#\\[\\]]")
     }
 
     /**

--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -39,7 +39,7 @@ internal const val X_OPERATION_ID = "x-operation-id"
 internal const val X_UNSAFE_OPERATION = "x-unsafe-operation"
 
 // Headers Names
-internal const val HEADER_X_OPERATION_ID = "X-Operation-Id"
+internal const val HEADER_X_OPERATION_ID = "X-Operation-ID"
 internal const val HEADER_CONTENT_TYPE = "Content-Type"
 
 abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {

--- a/samples/junit-tests/junit_tests_specs.json
+++ b/samples/junit-tests/junit_tests_specs.json
@@ -397,59 +397,6 @@
         "version": "1.1.0"
     },
     "paths": {
-        "/brackets/in/parameter/name": {
-            "get": {
-                "description": "Make sure that brackets in parameter name are treated properly",
-                "operationId": "getBracketsInParameterName",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "page",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "page[]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[before]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[strictly_before]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[after]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[strictly_after]",
-                        "required": false,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation"
-                    }
-                },
-                "summary": "Test brackets in parameter name",
-                "tags": [
-                    "resource"
-                ]
-            }
-        },
         "/empty_endpoint": {
             "get": {
                 "operationId": "get_empty_endpoint",
@@ -609,6 +556,53 @@
                         }
                     }
                 },
+                "tags": [
+                    "resource"
+                ]
+            }
+        },
+        "/symbols/in/parameter/name": {
+            "get": {
+                "description": "Make sure that symbols in parameter name are treated properly",
+                "operationId": "getSymbolsInParameterName",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "parameter",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "brackets[]",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "brackets[withText]",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "dot.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "dot.withText",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    }
+                },
+                "summary": "Test symbols in parameter name",
                 "tags": [
                     "resource"
                 ]

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
@@ -25,37 +25,11 @@ import retrofit2.http.Headers
 @JvmSuppressWildcards
 interface ResourceApi {
     /**
-     * Test brackets in parameter name
-     * Make sure that brackets in parameter name are treated properly
-     * The endpoint is owned by junittests service owner
-     * @param page (optional)
-     * @param page2 (optional)
-     * @param datePostedBefore (optional)
-     * @param datePostedStrictlyBefore (optional)
-     * @param datePostedAfter (optional)
-     * @param datePostedStrictlyAfter (optional)
-     */
-    @Headers(
-            "X-Operation-ID: getBracketsInParameterName"
-    )
-
-    @GET("/brackets/in/parameter/name")
-    fun getBracketsInParameterName(
-        @retrofit2.http.Query("page") page: String?,
-        @retrofit2.http.Query("page[]") page2: String?,
-        @retrofit2.http.Query("datePosted[before]") datePostedBefore: String?,
-        @retrofit2.http.Query("datePosted[strictly_before]") datePostedStrictlyBefore: String?,
-        @retrofit2.http.Query("datePosted[after]") datePostedAfter: String?,
-        @retrofit2.http.Query("datePosted[strictly_after]") datePostedStrictlyAfter: String?
-    ): Completable
-
-    /**
      * The endpoint is owned by junittests service owner
      */
     @Headers(
             "X-Operation-ID: get_empty_endpoint"
     )
-
     @GET("/empty_endpoint")
     fun getEmptyEndpoint(): Single<EmptyModel>
 
@@ -66,7 +40,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_format_endpoint"
     )
-
     @GET("/format_endpoint/{property_format}")
     fun getFormatEndpoint(
         @retrofit2.http.Path("property_format") propertyFormat: String
@@ -78,7 +51,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_nested_additional_properties"
     )
-
     @GET("/nested_additional_properties")
     fun getNestedAdditionalProperties(): Single<NestedAdditionalProperties>
 
@@ -88,7 +60,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_nested_additional_properties_custom_description"
     )
-
     @GET("/nested_additional_properties/custom_description")
     fun getNestedAdditionalPropertiesCustomDescription(): Single<NestedAdditionalPropertiesCustomDescription>
 
@@ -100,7 +71,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_property_array"
     )
-
     @GET("/property_array/{value_type}/{size}")
     fun getPropertyArray(
         @retrofit2.http.Path("value_type") valueType: String,
@@ -115,7 +85,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_property_map"
     )
-
     @GET("/property_map/{value_type}/{size}")
     fun getPropertyMap(
         @retrofit2.http.Path("value_type") valueType: String,
@@ -128,7 +97,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_required_type_endpoint"
     )
-
     @GET("/required/type_endpoint")
     fun getRequiredTypeEndpoint(): Single<RequiredTypeResponses>
 
@@ -138,9 +106,30 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_reserved_keywords"
     )
-
     @GET("/reserved_keywords")
     fun getReservedKeywords(): Single<ReservedKeywords>
+
+    /**
+     * Test symbols in parameter name
+     * Make sure that symbols in parameter name are treated properly
+     * The endpoint is owned by junittests service owner
+     * @param parameter (optional)
+     * @param brackets (optional)
+     * @param bracketsWithText (optional)
+     * @param dot (optional)
+     * @param dotWithText (optional)
+     */
+    @Headers(
+            "X-Operation-ID: getSymbolsInParameterName"
+    )
+    @GET("/symbols/in/parameter/name")
+    fun getSymbolsInParameterName(
+        @retrofit2.http.Query("parameter") parameter: String?,
+        @retrofit2.http.Query("brackets[]") brackets: String?,
+        @retrofit2.http.Query("brackets[withText]") bracketsWithText: String?,
+        @retrofit2.http.Query("dot.") dot: String?,
+        @retrofit2.http.Query("dot.withText") dotWithText: String?
+    ): Completable
 
     /**
      * The endpoint is owned by junittests service owner
@@ -148,7 +137,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_top_level_enum"
     )
-
     @GET("/top_level_enum")
     fun getTopLevelEnum(): Single<TopLevelEnum>
 
@@ -159,7 +147,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_top_level_map"
     )
-
     @GET("/top_level_map/{size}")
     fun getTopLevelMap(
         @retrofit2.http.Path("size") size: String
@@ -172,7 +159,6 @@ interface ResourceApi {
     @Headers(
             "X-Operation-ID: get_type_endpoint"
     )
-
     @GET("/type_endpoint/{property_type}")
     fun getTypeEndpoint(
         @retrofit2.http.Path("property_type") propertyType: String

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/XnullableApi.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/XnullableApi.kt
@@ -27,7 +27,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_format_endpoint"
     )
-
     @GET("/xnullable/format_endpoint/{property_format}")
     fun getXnullableFormatEndpoint(
         @retrofit2.http.Path("property_format") propertyFormat: String
@@ -39,7 +38,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_nested_additional_properties"
     )
-
     @GET("/xnullable/nested_additional_properties")
     fun getXnullableNestedAdditionalProperties(): Single<XnullableNestedAdditionalProperties>
 
@@ -51,7 +49,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_property_array"
     )
-
     @GET("/xnullable/property_array/{value_type}/{size}")
     fun getXnullablePropertyArray(
         @retrofit2.http.Path("value_type") valueType: String,
@@ -66,7 +63,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_property_map"
     )
-
     @GET("/xnullable/property_map/{value_type}/{size}")
     fun getXnullablePropertyMap(
         @retrofit2.http.Path("value_type") valueType: String,
@@ -80,7 +76,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_required_property_array"
     )
-
     @GET("/xnullable/required/property_array/{size}")
     fun getXnullableRequiredPropertyArray(
         @retrofit2.http.Path("size") size: String
@@ -93,7 +88,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_required_property_map"
     )
-
     @GET("/xnullable/required/property_map/{size}")
     fun getXnullableRequiredPropertyMap(
         @retrofit2.http.Path("size") size: String
@@ -106,7 +100,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_required_type_endpoint"
     )
-
     @GET("/xnullable/required/type_endpoint/{property_type}")
     fun getXnullableRequiredTypeEndpoint(
         @retrofit2.http.Path("property_type") propertyType: String
@@ -119,7 +112,6 @@ interface XnullableApi {
     @Headers(
             "X-Operation-ID: get_xnullable_type_endpoint"
     )
-
     @GET("/xnullable/type_endpoint/{property_type}")
     fun getXnullableTypeEndpoint(
         @retrofit2.http.Path("property_type") propertyType: String

--- a/samples/junit-tests/src/main/java/swagger.json
+++ b/samples/junit-tests/src/main/java/swagger.json
@@ -399,59 +399,6 @@
         "version": "1.1.0"
     },
     "paths": {
-        "/brackets/in/parameter/name": {
-            "get": {
-                "description": "Make sure that brackets in parameter name are treated properly",
-                "operationId": "getBracketsInParameterName",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "page",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "page[]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[before]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[strictly_before]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[after]",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "datePosted[strictly_after]",
-                        "required": false,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation"
-                    }
-                },
-                "summary": "Test brackets in parameter name",
-                "tags": [
-                    "resource"
-                ]
-            }
-        },
         "/empty_endpoint": {
             "get": {
                 "operationId": "get_empty_endpoint",
@@ -616,6 +563,53 @@
                         }
                     }
                 },
+                "tags": [
+                    "resource"
+                ]
+            }
+        },
+        "/symbols/in/parameter/name": {
+            "get": {
+                "description": "Make sure that symbols in parameter name are treated properly",
+                "operationId": "getSymbolsInParameterName",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "parameter",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "brackets[]",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "brackets[withText]",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "dot.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "dot.withText",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    }
+                },
+                "summary": "Test symbols in parameter name",
                 "tags": [
                     "resource"
                 ]

--- a/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/ValidParameterTest.kt
+++ b/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/ValidParameterTest.kt
@@ -14,28 +14,26 @@ class ValidParameterTest {
     val mockServerRule = MockServerApiRule()
 
     @Test
-    fun bracketsInParameterName() {
+    fun symbolsInParameterName() {
         mockServerRule.server.enqueue(MockResponse())
 
         val defaultApi = mockServerRule.getApi<ResourceApi>()
-        val pet = defaultApi.getBracketsInParameterName(
-                page = "testPage",
-                page2 = "testPage2",
-                datePostedAfter = "testDatePostedAfter",
-                datePostedBefore = "testDatePostedBefore",
-                datePostedStrictlyAfter = "testDatePostedStrictlyAfter",
-                datePostedStrictlyBefore = "testDatePostedStrictlyBefore"
+        val pet = defaultApi.getSymbolsInParameterName(
+                parameter = "testParameter",
+                brackets = "testBrackets",
+                bracketsWithText = "testBracketsWithText",
+                dot = "testDot",
+                dotWithText = "testDotWithText"
         ).blockingGet()
 
         val requestPath = mockServerRule.server.takeRequest().path
         assertNull(pet)
 
         // Let's check if the query parameters are encoded properly.
-        assertTrue("page=testPage" in requestPath)
-        assertTrue("page%5B%5D=testPage2" in requestPath)
-        assertTrue("datePosted%5Bbefore%5D=testDatePostedBefore" in requestPath)
-        assertTrue("datePosted%5Bafter%5D=testDatePostedAfter" in requestPath)
-        assertTrue("datePosted%5Bstrictly_before%5D=testDatePostedStrictlyBefore" in requestPath)
-        assertTrue("datePosted%5Bstrictly_after%5D=testDatePostedStrictlyAfter" in requestPath)
+        assertTrue("parameter=testParameter" in requestPath)
+        assertTrue("brackets%5B%5D=testBrackets" in requestPath)
+        assertTrue("brackets%5BwithText%5D=testBracketsWithText" in requestPath)
+        assertTrue("dot.=testDot" in requestPath)
+        assertTrue("dot.withText=testDotWithText" in requestPath)
     }
 }


### PR DESCRIPTION
The change is really trivial as I'm allowing dots in parameter names for operation. The diff is a bit bigger as I added some test as well as updated Swagger specs for Junit tests.

Fixes #73