### PR TITLE
Fix Nullability warning in JsonAdapters

### DIFF
--- a/plugin/src/main/resources/kotlin/tools/TypesAdapters.kt.mustache
+++ b/plugin/src/main/resources/kotlin/tools/TypesAdapters.kt.mustache
@@ -59,8 +59,8 @@ internal class LocalDateAdapter : XNullableJsonAdapter<LocalDate>() {
 
     override fun fromNonNullString(nextString: String) : LocalDate = LocalDate.parse(nextString, formatter)
 
-    override fun toJson(writer: JsonWriter?, value: LocalDate?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: LocalDate?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
@@ -76,15 +76,15 @@ internal class ZonedDateTimeAdapter : XNullableJsonAdapter<ZonedDateTime>() {
         }
     }
 
-    override fun toJson(writer: JsonWriter?, value: ZonedDateTime?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: ZonedDateTime?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
 internal class BigDecimalJsonAdapter : XNullableJsonAdapter<BigDecimal>() {
     override fun fromNonNullString(nextString: String) = BigDecimal(nextString)
 
-    override fun toJson(writer: JsonWriter?, value: BigDecimal?) {
-        value?.let { writer?.value(it) }
+    override fun toJson(writer: JsonWriter, value: BigDecimal?) {
+        value?.let { writer.value(it) }
     }
 }

--- a/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/models/Pet.kt
+++ b/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/models/Pet.kt
@@ -10,8 +10,8 @@ import com.squareup.moshi.Json
 
 /**
  * Represents a specific Pet in the store
- * @property id Unique ID of this Pet
  * @property category Optional category of the pet
+ * @property id Unique ID of this Pet
  * @property name Name of this specific pet
  * @property photoUrls Photo URls for this Pet on the bucket
  * @property tags Pet status in the store
@@ -19,7 +19,7 @@ import com.squareup.moshi.Json
 data class Pet(
     @Json(name = "name") @field:Json(name = "name") var name: String,
     @Json(name = "photoUrls") @field:Json(name = "photoUrls") var photoUrls: List<String>,
-    @Json(name = "id") @field:Json(name = "id") var id: Long? = null,
     @Json(name = "category") @field:Json(name = "category") var category: Category? = null,
+    @Json(name = "id") @field:Json(name = "id") var id: Long? = null,
     @Json(name = "tags") @field:Json(name = "tags") var tags: List<Tag>? = null
 )

--- a/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/tools/TypesAdapters.kt
+++ b/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/tools/TypesAdapters.kt
@@ -18,7 +18,7 @@ import java.math.BigDecimal
  * Moshi Factory to handle all the custom types we want to support,
  * such as [LocalDate], [ZonedDateTime], [BigDecimal].
  */
-internal class TypesAdapterFactory : JsonAdapter.Factory {
+class TypesAdapterFactory : JsonAdapter.Factory {
     private val types = mapOf<Type, JsonAdapter<*>>(
             LocalDate::class.java to LocalDateAdapter(),
             ZonedDateTime::class.java to ZonedDateTimeAdapter(),
@@ -59,8 +59,8 @@ internal class LocalDateAdapter : XNullableJsonAdapter<LocalDate>() {
 
     override fun fromNonNullString(nextString: String): LocalDate = LocalDate.parse(nextString, formatter)
 
-    override fun toJson(writer: JsonWriter?, value: LocalDate?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: LocalDate?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
@@ -76,15 +76,15 @@ internal class ZonedDateTimeAdapter : XNullableJsonAdapter<ZonedDateTime>() {
         }
     }
 
-    override fun toJson(writer: JsonWriter?, value: ZonedDateTime?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: ZonedDateTime?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
 internal class BigDecimalJsonAdapter : XNullableJsonAdapter<BigDecimal>() {
     override fun fromNonNullString(nextString: String) = BigDecimal(nextString)
 
-    override fun toJson(writer: JsonWriter?, value: BigDecimal?) {
-        value?.let { writer?.value(it) }
+    override fun toJson(writer: JsonWriter, value: BigDecimal?) {
+        value?.let { writer.value(it) }
     }
 }

--- a/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/tools/XNullableAdapterFactory.kt
+++ b/samples/generated-code/src/main/java/com/yelp/codegen/generatecodesamples/tools/XNullableAdapterFactory.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import java.lang.reflect.Type
 
-internal class XNullableAdapterFactory : JsonAdapter.Factory {
+class XNullableAdapterFactory : JsonAdapter.Factory {
     override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
         if (annotations.any { it is XNullable }) {
             return object : JsonAdapter<Any>() {

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/tools/TypesAdapters.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/tools/TypesAdapters.kt
@@ -59,8 +59,8 @@ internal class LocalDateAdapter : XNullableJsonAdapter<LocalDate>() {
 
     override fun fromNonNullString(nextString: String): LocalDate = LocalDate.parse(nextString, formatter)
 
-    override fun toJson(writer: JsonWriter?, value: LocalDate?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: LocalDate?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
@@ -76,15 +76,15 @@ internal class ZonedDateTimeAdapter : XNullableJsonAdapter<ZonedDateTime>() {
         }
     }
 
-    override fun toJson(writer: JsonWriter?, value: ZonedDateTime?) {
-        value?.let { writer?.value(it.format(formatter)) }
+    override fun toJson(writer: JsonWriter, value: ZonedDateTime?) {
+        value?.let { writer.value(it.format(formatter)) }
     }
 }
 
 internal class BigDecimalJsonAdapter : XNullableJsonAdapter<BigDecimal>() {
     override fun fromNonNullString(nextString: String) = BigDecimal(nextString)
 
-    override fun toJson(writer: JsonWriter?, value: BigDecimal?) {
-        value?.let { writer?.value(it) }
+    override fun toJson(writer: JsonWriter, value: BigDecimal?) {
+        value?.let { writer.value(it) }
     }
 }


### PR DESCRIPTION
Updating generated methods `toJson` to accept a non null `JsonWriter`.
Previously the IDE was raising an issue due to different method signature.

Fixes #74

Ping @macisamuele for the review