### PR TITLE
Fix missing inner enum import on operations

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -427,6 +427,24 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
     }
 
     /**
+     * Resolve the inner type from a complex type. E.g:
+     * List<List<Int>> ---> Int
+     * Map<String, Map<String, List<Object>>> ---> Object
+     */
+    internal tailrec fun resolveInnerType(
+        baseType: String
+    ): String {
+        if (isListTypeWrapped(baseType)) {
+            return resolveInnerType(listTypeUnwrapper(baseType))
+        }
+        if (isMapTypeWrapped(baseType)) {
+            return resolveInnerType(mapTypeUnwrapper(baseType))
+        }
+
+        return baseType
+    }
+
+    /**
      * Determine if the swagger operation consumes mutipart content.
      */
     private fun isMultipartOperation(operation: Operation?): Boolean {
@@ -469,6 +487,21 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
     protected abstract fun listTypeWrapper(listType: String, innerType: String): String
 
     /**
+     * Abstract function to unwrap a JSON Array type.
+     * @param baseType A JSON list type (e.g. `List<String>`)
+     * @return The unwrapped inner type (e.g. `String`).
+     * @see isListTypeWrapped
+     */
+    protected abstract fun listTypeUnwrapper(baseType: String): String
+
+    /**
+     * Abstract function to check if a type is a JSON Array type.
+     * @param baseType A JSON type
+     * @return True if the type is a JSON Array type and can be safely unwrapped with [listTypeUnwrapper]
+     */
+    protected abstract fun isListTypeWrapped(baseType: String): Boolean
+
+    /**
      * Abstract function to create a type for a JSON Object (A Map from String to values).
      * Please note that in JSON Maps have only Strings as keys.
      *
@@ -477,6 +510,21 @@ abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
      * @return The composed map type (e.g. `Map<String, Any?>`, `[String: Integer]`, etc.
      */
     protected abstract fun mapTypeWrapper(mapType: String, innerType: String): String
+
+    /**
+     * Abstract function to unwrap a JSON Map type.
+     * @param baseType A JSON map type (e.g. `Map<String, Item>`)
+     * @return The unwrapped inner type (e.g. `Item`).
+     * @see isMapTypeWrapped
+     */
+    protected abstract fun mapTypeUnwrapper(baseType: String): String
+
+    /**
+     * Abstract function to check if a type is a JSON Map type.
+     * @param baseType A JSON type
+     * @return True if the type is a JSON Map type and can be safely unwrapped with [mapTypeUnwrapper]
+     */
+    protected abstract fun isMapTypeWrapped(baseType: String): Boolean
 
     /**
      * Abstract function to create a type from a Nullable type.

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -30,31 +30,6 @@ class KotlinGeneratorTest {
     }
 
     @Test
-    fun listTypeWrapper_withSimpleType() {
-        assertEquals("List<String>", KotlinGenerator().listTypeWrapper("List", "String"))
-    }
-
-    @Test
-    fun listTypeWrapper_withMultipleNesting() {
-        assertEquals("List<List<String>>", KotlinGenerator().listTypeWrapper("List", "List<String>"))
-    }
-
-    @Test
-    fun mapTypeWrapper_withSimpleType() {
-        assertEquals("Map<String, Any>", KotlinGenerator().mapTypeWrapper("Map", "Any"))
-    }
-
-    @Test
-    fun mapTypeWrapper_withMultipleNesting() {
-        assertEquals("HashMap<String, List<Any?>?>", KotlinGenerator().mapTypeWrapper("HashMap", "List<Any?>?"))
-    }
-
-    @Test
-    fun nullableTypeWrapper_withSimpleType() {
-        assertEquals("String?", KotlinGenerator().nullableTypeWrapper("String"))
-    }
-
-    @Test
     fun escapeUnsafeCharacters_withNothingToEscape() {
         assertEquals("Nothing", KotlinGenerator().escapeUnsafeCharacters("Nothing"))
     }
@@ -154,7 +129,7 @@ class KotlinGeneratorTest {
         val generator = KotlinGenerator()
         generator.additionalProperties()[GROUP_ID] = "com.yelp"
         generator.additionalProperties()[ARTIFACT_ID] = "test"
-        val sep:String = File.separator
+        val sep: String = File.separator
         assertTrue(generator.modelFileFolder().endsWith("com${sep}yelp${sep}test${sep}models"))
     }
 

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGenerator_TypeMappersTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGenerator_TypeMappersTest.kt
@@ -1,0 +1,104 @@
+package com.yelp.codegen
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KotlinGenerator_TypeMappersTest {
+
+    @Test
+    fun listTypeWrapper_withSimpleType() {
+        assertEquals("List<String>", KotlinGenerator().listTypeWrapper("List", "String"))
+    }
+
+    @Test
+    fun listTypeWrapper_withMultipleNesting() {
+        assertEquals("List<List<String>>", KotlinGenerator().listTypeWrapper("List", "List<String>"))
+    }
+
+    @Test
+    fun listTypeUnwrapper_withSimpleType() {
+        assertEquals("String", KotlinGenerator().listTypeUnwrapper("String"))
+    }
+
+    @Test
+    fun listTypeUnwrapper_withListType() {
+        assertEquals("String", KotlinGenerator().listTypeUnwrapper("List<String>"))
+    }
+
+    @Test
+    fun isListTypeWrapped_withSimpleType() {
+        assertFalse(KotlinGenerator().isListTypeWrapped("String"))
+    }
+
+    @Test
+    fun isListTypeWrapped_withListType() {
+        assertTrue(KotlinGenerator().isListTypeWrapped("List<String>"))
+    }
+
+    @Test
+    fun isListTypeWrapped_withMapType() {
+        assertFalse(KotlinGenerator().isListTypeWrapped("Map<String, Int>"))
+    }
+
+    @Test
+    fun mapTypeWrapper_withSimpleType() {
+        assertEquals("Map<String, Any>", KotlinGenerator().mapTypeWrapper("Map", "Any"))
+    }
+
+    @Test
+    fun mapTypeWrapper_withMultipleNesting() {
+        assertEquals("HashMap<String, List<Any?>?>", KotlinGenerator().mapTypeWrapper("HashMap", "List<Any?>?"))
+    }
+
+    @Test
+    fun mapTypeUnwrapper_withSimpleType() {
+        assertEquals("String", KotlinGenerator().mapTypeUnwrapper("String"))
+    }
+
+    @Test
+    fun mapTypeUnwrapper_withMapType() {
+        assertEquals("Int", KotlinGenerator().mapTypeUnwrapper("Map<String, Int>"))
+    }
+
+    @Test
+    fun isMapTypeWrapped_withSimpleType() {
+        assertFalse(KotlinGenerator().isMapTypeWrapped("String"))
+    }
+
+    @Test
+    fun isMapTypeWrapped_withListType() {
+        assertFalse(KotlinGenerator().isMapTypeWrapped("List<String>"))
+    }
+
+    @Test
+    fun isMapTypeWrapped_withMapType() {
+        assertTrue(KotlinGenerator().isMapTypeWrapped("Map<String, Int>"))
+    }
+
+    @Test
+    fun nullableTypeWrapper_withSimpleType() {
+        assertEquals("String?", KotlinGenerator().nullableTypeWrapper("String"))
+    }
+
+    @Test
+    fun resolveInnerType_withSimpleType() {
+        assertEquals("String", KotlinGenerator().resolveInnerType("String"))
+    }
+
+    @Test
+    fun resolveInnerType_withListType() {
+        assertEquals("String", KotlinGenerator().resolveInnerType("List<String>"))
+    }
+
+    @Test
+    fun resolveInnerType_withMapType() {
+        assertEquals("Int", KotlinGenerator().resolveInnerType("Map<String, Int>"))
+    }
+
+    @Test
+    fun resolveInnerType_withComplexType() {
+        assertEquals("Int", KotlinGenerator().resolveInnerType("Map<String, Map<String, List<Map<String, Int>>>>"))
+    }
+}

--- a/samples/junit-tests/junit_tests_specs.json
+++ b/samples/junit-tests/junit_tests_specs.json
@@ -624,6 +624,28 @@
                 ]
             }
         },
+        "/top_level_enum/nested": {
+            "get": {
+                "operationId": "get_top_level_enum_nested",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "additionalProperties": {
+                                "additionalProperties": {
+                                    "$ref": "#/definitions/top_level_enum"
+                                },
+                                "type": "object"
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "tags": [
+                    "resource"
+                ]
+            }
+        },
         "/top_level_map/{size}": {
             "get": {
                 "operationId": "get_top_level_map",

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
@@ -142,6 +142,15 @@ interface ResourceApi {
 
     /**
      * The endpoint is owned by junittests service owner
+     */
+    @Headers(
+            "X-Operation-ID: get_top_level_enum_nested"
+    )
+    @GET("/top_level_enum/nested")
+    fun getTopLevelEnumNested(): Single<Map<String, Map<String, TopLevelEnum>>>
+
+    /**
+     * The endpoint is owned by junittests service owner
      * @param size (required)
      */
     @Headers(

--- a/samples/junit-tests/src/main/java/swagger.json
+++ b/samples/junit-tests/src/main/java/swagger.json
@@ -632,6 +632,29 @@
                 ]
             }
         },
+        "/top_level_enum/nested": {
+            "get": {
+                "operationId": "get_top_level_enum_nested",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "additionalProperties": {
+                                "additionalProperties": {
+                                    "$ref": "#/definitions/top_level_enum"
+                                },
+                                "type": "object"
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "tags": [
+                    "resource"
+                ]
+            }
+        },
         "/top_level_map/{size}": {
             "get": {
                 "operationId": "get_top_level_map",

--- a/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/TopLevelEnumEndpointTest.kt
+++ b/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/TopLevelEnumEndpointTest.kt
@@ -20,4 +20,18 @@ class TopLevelEnumEndpointTest {
         val returned = rule.getApi<ResourceApi>().getTopLevelEnum().blockingGet()
         assertEquals(TopLevelEnum.VALUE1, returned)
     }
+
+    @Test
+    fun topLevelEnumNestedEndpoint() {
+        rule.server.enqueue(MockResponse().setBody("""
+            {
+                "key1": {
+                    "key2": "TOP_LEVEL_VALUE1"
+                }
+            }
+        """.trimIndent()))
+
+        val returned = rule.getApi<ResourceApi>().getTopLevelEnumNested().blockingGet()
+        assertEquals(TopLevelEnum.VALUE1, returned["key1"]?.get("key2"))
+    }
 }


### PR DESCRIPTION
Previously inner types of complex types were not imported properly on
operations. This resulted in Retrofit interfaces missing some imports.

This commit introduces methods to inspect and import the inner types
used as result types of operations.

Fixes #76

Ping @macisamuele for the review