### PR TITLE
Prepare Release v1.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Here you can find the release notes for this project. Please note that list of releases is available also in the [releases](https://github.com/Yelp/swagger-gradle-codegen/releases) page on Github.
 
-## v1.3.0 (2020-01-20)
+## v1.3.0 (2020-01-21)
 
 * 🎁 Kotlin Coroutines Support [#29]
 * 🐛 Allow dot in parameter names for operations [#77]
@@ -11,6 +11,7 @@ Here you can find the release notes for this project. Please note that list of r
 * 🐛 Fix Gradle Portal URL in settings.gradle.kts breaking Gradle syncs [#59]
 * 🐛 Issue 55 failing windows tests [#56]
 * ⚙️ Update multiple dependencies [#64]
+* ⚙️ Update several dependencies [#80]
 * ⚙️ Gradle to 5.6.2 [#67]
 * ⚙️ Add JaCoCo for CodeCov [#66]
 
@@ -76,3 +77,4 @@ Thanks to @cortinico, @MatthewTPage, @GuilhE, @macisamuele and @redwarp for the 
 [#77]: https://github.com/Yelp/swagger-gradle-codegen/pull/77/
 [#78]: https://github.com/Yelp/swagger-gradle-codegen/pull/78/
 [#79]: https://github.com/Yelp/swagger-gradle-codegen/pull/79/
+[#80]: https://github.com/Yelp/swagger-gradle-codegen/pull/80/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 Here you can find the release notes for this project. Please note that list of releases is available also in the [releases](https://github.com/Yelp/swagger-gradle-codegen/releases) page on Github.
 
+## v1.3.0 (2020-01-20)
+
+* 🎁 Kotlin Coroutines Support [#29]
+* 🐛 Allow dot in parameter names for operations [#77]
+* 🐛 Fix Nullability warning in JsonAdapters [#78]
+* 🐛 Fix missing inner enum import on operations [#79]
+* 🐛 Fix Gradle Portal URL in settings.gradle.kts breaking Gradle syncs [#59]
+* 🐛 Issue 55 failing windows tests [#56]
+* ⚙️ Update multiple dependencies [#64]
+* ⚙️ Gradle to 5.6.2 [#67]
+* ⚙️ Add JaCoCo for CodeCov [#66]
+
+Thanks to @cortinico @doug-precocity @redwarp @macisamuele @filipemp for the support with this release
+
 ## v1.2.0 (2019-07-31)
 
 * 🎁 Remove leading slash if Swagger Spec are specifying a basePath [#50]
@@ -44,6 +58,7 @@ Thanks to @cortinico, @MatthewTPage, @GuilhE, @macisamuele and @redwarp for the 
 [#22]: https://github.com/Yelp/swagger-gradle-codegen/pull/22/
 [#23]: https://github.com/Yelp/swagger-gradle-codegen/pull/23/
 [#26]: https://github.com/Yelp/swagger-gradle-codegen/pull/26/
+[#29]: https://github.com/Yelp/swagger-gradle-codegen/pull/29/
 [#30]: https://github.com/Yelp/swagger-gradle-codegen/pull/30/
 [#32]: https://github.com/Yelp/swagger-gradle-codegen/pull/32/
 [#39]: https://github.com/Yelp/swagger-gradle-codegen/pull/39/
@@ -53,3 +68,11 @@ Thanks to @cortinico, @MatthewTPage, @GuilhE, @macisamuele and @redwarp for the 
 [#48]: https://github.com/Yelp/swagger-gradle-codegen/pull/48/
 [#50]: https://github.com/Yelp/swagger-gradle-codegen/pull/50/
 [#52]: https://github.com/Yelp/swagger-gradle-codegen/pull/52/
+[#56]: https://github.com/Yelp/swagger-gradle-codegen/pull/56/
+[#59]: https://github.com/Yelp/swagger-gradle-codegen/pull/59/
+[#64]: https://github.com/Yelp/swagger-gradle-codegen/pull/64/
+[#66]: https://github.com/Yelp/swagger-gradle-codegen/pull/66/
+[#67]: https://github.com/Yelp/swagger-gradle-codegen/pull/67/
+[#77]: https://github.com/Yelp/swagger-gradle-codegen/pull/77/
+[#78]: https://github.com/Yelp/swagger-gradle-codegen/pull/78/
+[#79]: https://github.com/Yelp/swagger-gradle-codegen/pull/79/

--- a/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
+++ b/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
@@ -1,7 +1,7 @@
 @file:Suppress("Unused")
 
 object PublishingVersions {
-    const val PLUGIN_VERSION = "1.2.0"
+    const val PLUGIN_VERSION = "1.3.0"
     const val PLUGIN_GROUP = "com.yelp.codegen"
     const val PLUGIN_ARTIFACT = "plugin"
 }

--- a/samples/generated-code/build.gradle
+++ b/samples/generated-code/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
-        classpath "com.yelp.codegen:plugin:1.2.0"
+        classpath "com.yelp.codegen:plugin:1.3.0"
     }
 }
 

--- a/samples/groovy-android/build.gradle
+++ b/samples/groovy-android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
-        classpath "com.yelp.codegen:plugin:1.2.0"
+        classpath "com.yelp.codegen:plugin:1.3.0"
     }
 }
 

--- a/samples/junit-tests/build.gradle
+++ b/samples/junit-tests/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
-        classpath "com.yelp.codegen:plugin:1.2.0"
+        classpath "com.yelp.codegen:plugin:1.3.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.4.0"
     }
 }

--- a/samples/kotlin-android/build.gradle.kts
+++ b/samples/kotlin-android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library") version "3.5.3"
     kotlin("android") version "1.3.61"
-    id("com.yelp.codegen.plugin") version "1.2.0"
+    id("com.yelp.codegen.plugin") version "1.3.0"
 }
 
 android {

--- a/samples/kotlin-coroutines/build.gradle
+++ b/samples/kotlin-coroutines/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
-        classpath "com.yelp.codegen:plugin:1.2.0"
+        classpath "com.yelp.codegen:plugin:1.3.0"
     }
 }
 


### PR DESCRIPTION
The latest version of the plugin was released in July. Time to ship support for coroutines as well as multiple bugfixes.