### PR TITLE
Update lint suppression directives and update jacoco version

### DIFF
--- a/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
+++ b/buildSrc/src/main/java/com/yelp/codegen/gradle/PublishingVersions.kt
@@ -1,7 +1,6 @@
-@file:Suppress("Unused")
-
 object PublishingVersions {
     const val PLUGIN_VERSION = "1.3.0"
     const val PLUGIN_GROUP = "com.yelp.codegen"
+    @Suppress("UNUSED")
     const val PLUGIN_ARTIFACT = "plugin"
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -19,7 +19,7 @@ java {
 }
 
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.5"
 }
 
 dependencies {

--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions", "NOTHING_TO_INLINE")
-
 package com.yelp.codegen
 
 import com.google.common.annotations.VisibleForTesting
@@ -21,6 +19,7 @@ import io.swagger.models.Swagger
 import io.swagger.models.properties.Property
 import java.io.File
 
+@Suppress("TooManyFunctions")
 open class KotlinGenerator : SharedCodegen() {
 
     companion object {
@@ -374,6 +373,7 @@ open class KotlinGenerator : SharedCodegen() {
     /**
      * Check if a name is of the type `com.x.name`, which means it has a fully qualified package.
      */
+    @Suppress("NOTHING_TO_INLINE")
     private inline fun String.isFullyQualifiedImportName() = "." in this
 
     override fun postProcessModels(objs: Map<String, Any>): Map<String, Any> {

--- a/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
+++ b/plugin/src/main/java/com/yelp/codegen/SharedCodegen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.yelp.codegen
 
 import com.yelp.codegen.utils.InlineModelResolver
@@ -43,6 +41,7 @@ internal const val X_UNSAFE_OPERATION = "x-unsafe-operation"
 internal const val HEADER_X_OPERATION_ID = "X-Operation-ID"
 internal const val HEADER_CONTENT_TYPE = "Content-Type"
 
+@Suppress("TooManyFunctions")
 abstract class SharedCodegen : DefaultCodegen(), CodegenConfig {
 
     // Reference to the Swagger Specs

--- a/plugin/src/main/java/com/yelp/codegen/plugin/GenerateTaskConfiguration.kt
+++ b/plugin/src/main/java/com/yelp/codegen/plugin/GenerateTaskConfiguration.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import java.io.File
 
-open class GenerateTaskConfiguration(project: Project) {
+open class GenerateTaskConfiguration(@Suppress("UNUSED_PARAMETER") project: Project) {
     var platform: String? = null
     var packageName: String? = null
     var specName: String? = null

--- a/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/PropertyMapEndpointTest.kt
+++ b/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/PropertyMapEndpointTest.kt
@@ -166,6 +166,11 @@ class PropertyMapEndpointTest {
         assertEquals("array_value1", (returned.objectMap?.get("key3") as List<*>)[0])
 
         assertFalse((returned.objectMap?.get("key4") as Map<*, *>).isEmpty())
-        assertEquals("map_value1", (returned.objectMap?.get("key4") as Map<String, Any>)["map_key1"])
+        assertEquals(
+            "map_value1", (
+                @Suppress("UNCHECKED_CAST")
+                (returned.objectMap?.get("key4") as Map<String, Any>)
+            )["map_key1"]
+        )
     }
 }

--- a/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/xnullable/XnullablePropertyMapEndpointTest.kt
+++ b/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/xnullable/XnullablePropertyMapEndpointTest.kt
@@ -271,7 +271,13 @@ class XnullablePropertyMapEndpointTest {
         assertEquals("array_value1", (returned.objectMap?.get("key3") as List<*>)[0])
 
         assertFalse((returned.objectMap?.get("key4") as Map<*, *>).isEmpty())
-        assertEquals("map_value1", (returned.objectMap?.get("key4") as Map<String, Any>)["map_key1"])
+        assertEquals(
+            "map_value1",
+            (
+                @Suppress("UNCHECKED_CAST")
+                (returned.objectMap?.get("key4") as Map<String, Any>)
+            )["map_key1"]
+        )
         assertNull(returned.objectMap?.get("key5"))
     }
 }


### PR DESCRIPTION
The goal of this PR is to make Suppression of warnings/lints as selective as possible.
This is mostly done to reduce warnings reporting while interacting with the tool (at least during development) and to reduce the probability that wide scope lint ignores (ie `@file:Suppress`) are hiding potential new issues.
