### PR TITLE
Run integration tests to improve reported coverage

### DIFF
--- a/plugin/src/test/java/com/yelp/codegen/MainTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/MainTest.kt
@@ -1,0 +1,43 @@
+package com.yelp.codegen
+import java.io.File
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MainTest {
+
+    private fun runGenerator(platform: String) {
+        val temporaryFolder = TemporaryFolder()
+        val junitTestsSpecsPath = File(
+            // Repo root
+            File(".").absoluteFile.parentFile.parentFile.absolutePath,
+            "samples${File.separator}junit-tests${File.separator}junit_tests_specs.json"
+        ).path
+
+        try {
+            temporaryFolder.create()
+            main(
+                listOf(
+                    "-p", platform,
+                    "-i", junitTestsSpecsPath,
+                    "-o", temporaryFolder.newFolder("kotlin").absolutePath,
+                    "-s", "junittests",
+                    "-v", "0.0.1",
+                    "-g", "com.yelp.codegen",
+                    "-a", " generatecodesamples"
+                ).toTypedArray()
+            )
+        } finally {
+            temporaryFolder.delete()
+        }
+    }
+
+    @Test
+    fun generateKotlinFromJUnitTestSampleSpecs() {
+        runGenerator("kotlin")
+    }
+
+    @Test
+    fun generateKotlinCoroutinesFromJUnitTestSampleSpecs() {
+        runGenerator("kotlin-coroutines")
+    }
+}


### PR DESCRIPTION
The main idea of this PR is to enhance reported coverage level.

The reasoning behind is that while running tests on travis we do actually generate `samples/junit-tests` and run tests on the generated code, but the execution does not actually contribute to the overall covered code.

Adding this "integration" tests like allows to actually report these covered lines as well.

You can see the report diff on https://codecov.io/gh/macisamuele/swagger-gradle-codegen/compare/9a23d299fe8a7b49e2228e3d0b2ae6a9f75da05e...8c20146919c3a1c0193ca999b18815699c0b7bc9