### PR TITLE
Annotate with @JsonClass classes with no parameters/variables

### DIFF
--- a/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -205,8 +205,13 @@ open class KotlinGenerator : SharedCodegen() {
     @VisibleForTesting
     internal fun addRequiredImports(codegenModel: CodegenModel) {
         // If there are any vars, we will mark them with the @Json annotation so we have to make sure to import it
-        if (codegenModel.vars.isNotEmpty() || codegenModel.isEnum) {
+        if (codegenModel.allVars.isNotEmpty() || codegenModel.isEnum) {
             codegenModel.imports.add("com.squareup.moshi.Json")
+        }
+
+        if (!codegenModel.isAlias) {
+            // If we are rendering a model (or enum) we are annotating it with @JsonClass,
+            // so we need to make sure that we're importing it
             codegenModel.imports.add("com.squareup.moshi.JsonClass")
         }
 

--- a/plugin/src/main/resources/kotlin/data_class.mustache
+++ b/plugin/src/main/resources/kotlin/data_class.mustache
@@ -4,8 +4,8 @@
  * @property {{{name}}} {{description}}
 {{/vars}}
  */
-{{#hasVars}}@JsonClass(generateAdapter = true)
-data {{/hasVars}}class {{classname}} {{#hasVars}}(
+@JsonClass(generateAdapter = true)
+{{#hasVars}}data {{/hasVars}}class {{classname}} {{#hasVars}}(
 {{#requiredVars}}
 {{>data_class_req_var}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},

--- a/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -44,11 +44,13 @@ class KotlinGeneratorTest {
         val model = CodegenModel()
         val property = CodegenProperty()
         property.vendorExtensions = mutableMapOf()
-        model.vars.add(property)
+        model.allVars.add(property)
 
         KotlinGenerator().addRequiredImports(model)
 
         assertTrue(model.imports.contains("com.squareup.moshi.Json"))
+        assertTrue(model.imports.contains("com.squareup.moshi.JsonClass"))
+        assertFalse(model.imports.contains("com.yelp.test.tools.XNullable"))
     }
 
     @Test
@@ -59,6 +61,20 @@ class KotlinGeneratorTest {
         KotlinGenerator().addRequiredImports(model)
 
         assertTrue(model.imports.contains("com.squareup.moshi.Json"))
+        assertTrue(model.imports.contains("com.squareup.moshi.JsonClass"))
+        assertFalse(model.imports.contains("com.yelp.test.tools.XNullable"))
+    }
+
+    @Test
+    fun addRequiredImports_withAlias() {
+        val model = CodegenModel()
+        model.isAlias = true
+
+        KotlinGenerator().addRequiredImports(model)
+
+        assertFalse(model.imports.contains("com.squareup.moshi.Json"))
+        assertFalse(model.imports.contains("com.squareup.moshi.JsonClass"))
+        assertFalse(model.imports.contains("com.yelp.test.tools.XNullable"))
     }
 
     @Test
@@ -74,6 +90,8 @@ class KotlinGeneratorTest {
 
         generator.addRequiredImports(model)
 
+        assertTrue(model.imports.contains("com.squareup.moshi.Json"))
+        assertTrue(model.imports.contains("com.squareup.moshi.JsonClass"))
         assertTrue(model.imports.contains("com.yelp.test.tools.XNullable"))
     }
 

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/models/EmptyModel.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/models/EmptyModel.kt
@@ -6,7 +6,10 @@
 
 package com.yelp.codegen.generatecodesamples.models
 
+import com.squareup.moshi.JsonClass
+
 /**
  *
  */
+@JsonClass(generateAdapter = true)
 class EmptyModel


### PR DESCRIPTION
This is needed because if we would fully remove `moshi-kotlin` dependency (as planned by version 2 release) we would not be able to properly have the Json to Object conversion and vice-versa.

The most important change introduced by this PR is visible into [`samples/junit-tests/.../models/EmptyModel.kt`](https://github.com/Yelp/swagger-gradle-codegen/compare/master...macisamuele:maci-support-moshi-codegen-empty-class-edge-case#diff-497b242f6dee935e9766b2969ed52f43).

The reason for forcing the presence of `@JsonClass(generateAdapter = true)` even if there are no attributes is related to the fact that if we would remove the usage of `KotlinJsonAdapterFactory` then we would not be able to covert the `EmptyModel` instance from/to `JSON`.

In order to validate it I've run [this script](https://gist.github.com/macisamuele/8705010811d9a20c2b12fd4a7372a049#file-script-sh).
The script basically ensures that we have no moshi-kotlin/kotlin-reflect dependencies on samples/junit-tests and runs the tests

The results (raw results in [here](https://gist.github.com/macisamuele/8705010811d9a20c2b12fd4a7372a049#file-script-sh-execution)), as expected, shows that:
 * **PR branch** leads to green tests
 * **current master** fails to run `emptyEndpointTest_withEmptyBody` test.
    The test failure contains the following exception (the raw exception is available [here](https://gist.github.com/macisamuele/8705010811d9a20c2b12fd4a7372a049#file-integral-exception))
```
java.lang.IllegalArgumentException: Unable to create converter for class com.yelp.codegen.generatecodesamples.models.EmptyModel
...
Caused by: java.lang.IllegalArgumentException: Cannot serialize Kotlin type com.yelp.codegen.generatecodesamples.models.EmptyModel. Reflective serialization of Kotlin classes without using kotlin-reflect has undefined and unexpected behavior. Please use KotlinJsonAdapter from the moshi-kotlin artifact or use code gen from the moshi-kotlin-codegen artifact.
```
