### PR TITLE
Update make test to run pre-commit hooks on the whole codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-hooks regenerate-samples test
+.PHONY: install-hooks regenerate-samples test run-hooks
 
 .git/hooks/pre-commit: venv
 	${CURDIR}/venv/bin/pre-commit install --install-hooks
@@ -11,7 +11,7 @@ regenerate-samples:
 	${CURDIR}/gradlew plugin:publishToMavenLocal
 	${CURDIR}/gradlew generateSwagger
 
-run-hooks: install-hooks
+run-hooks: venv
 	${CURDIR}/venv/bin/pre-commit run --all-files
 
 test: run-hooks
@@ -20,7 +20,6 @@ test: run-hooks
 	${CURDIR}/gradlew generateSwagger
 	${CURDIR}/gradlew assembleDebug
 	${CURDIR}/gradlew check
-	deactivate
 
 venv:
 	virtualenv venv

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,16 @@ regenerate-samples:
 	${CURDIR}/gradlew plugin:publishToMavenLocal
 	${CURDIR}/gradlew generateSwagger
 
-test:
+run-hooks: install-hooks
+	${CURDIR}/venv/bin/pre-commit run --all-files
+
+test: run-hooks
 	${CURDIR}/gradlew plugin:build
 	${CURDIR}/gradlew plugin:publishToMavenLocal
 	${CURDIR}/gradlew generateSwagger
 	${CURDIR}/gradlew assembleDebug
 	${CURDIR}/gradlew check
+	deactivate
 
 venv:
 	virtualenv venv


### PR DESCRIPTION
I was discussing with @macisamuele to eventually run all the precommit hooks on `make test`. This will prevent developers that don't have pre-commit installed to submit code that is invalid.