### PR TITLE
Cache pip and pre-commit folders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ android:
 
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock
-- rm -fr ${HOME}/.gradle/caches/*/plugin-resolution/
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ cache:
   - ${HOME}/.gradle/caches/
   - ${HOME}/.gradle/wrapper/
   - ${HOME}/.m2
+  - ${HOME}/.cache/pip/
+  - ${HOME}/.cache/pre-commit/
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ before_cache:
 - rm -fr ${HOME}/.gradle/caches/*/plugin-resolution/
 
 cache:
+  pip: true
   directories:
   - ${HOME}/.gradle/caches/
+  - ${HOME}/.cache/pre-commit/
   - ${HOME}/.gradle/wrapper/
   - ${HOME}/.m2
-  - ${HOME}/.cache/pip/
-  - ${HOME}/.cache/pre-commit/
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,6 @@ cache:
 
 script:
 - make test
+
+after_success:
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
As suggested in #92, caching pre-commit folders to speedup Travis runs.