### PR TITLE
Use TemporaryFolder JUnit-Test rule to create temporary directories

### DIFF
--- a/plugin/src/test/java/com/yelp/codegen/MainTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/MainTest.kt
@@ -1,34 +1,32 @@
 package com.yelp.codegen
 import java.io.File
+import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 class MainTest {
+    @Rule
+    @JvmField
+    val temporaryFolder = TemporaryFolder()
 
     private fun runGenerator(platform: String) {
-        val temporaryFolder = TemporaryFolder()
         val junitTestsSpecsPath = File(
             // Repo root
             File(".").absoluteFile.parentFile.parentFile.absolutePath,
             "samples${File.separator}junit-tests${File.separator}junit_tests_specs.json"
         ).path
 
-        try {
-            temporaryFolder.create()
-            main(
-                listOf(
-                    "-p", platform,
-                    "-i", junitTestsSpecsPath,
-                    "-o", temporaryFolder.newFolder("kotlin").absolutePath,
-                    "-s", "junittests",
-                    "-v", "0.0.1",
-                    "-g", "com.yelp.codegen",
-                    "-a", " generatecodesamples"
-                ).toTypedArray()
-            )
-        } finally {
-            temporaryFolder.delete()
-        }
+        main(
+            listOf(
+                "-p", platform,
+                "-i", junitTestsSpecsPath,
+                "-o", temporaryFolder.newFolder("kotlin").absolutePath,
+                "-s", "junittests",
+                "-v", "0.0.1",
+                "-g", "com.yelp.codegen",
+                "-a", " generatecodesamples"
+            ).toTypedArray()
+        )
     }
 
     @Test

--- a/plugin/src/test/java/com/yelp/codegen/MainTest.kt
+++ b/plugin/src/test/java/com/yelp/codegen/MainTest.kt
@@ -5,8 +5,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 class MainTest {
-    @Rule
-    @JvmField
+    @get:Rule
     val temporaryFolder = TemporaryFolder()
 
     private fun runGenerator(platform: String) {

--- a/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
+++ b/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
@@ -9,8 +9,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 class PluginTests {
-    @Rule
-    @JvmField
+    @get:Rule
     val temporaryFolder = TemporaryFolder(File("."))
 
     @Test

--- a/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
+++ b/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
@@ -4,23 +4,33 @@ import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class PluginTests {
+    @Rule
+    @JvmField
+    val temporaryFolder = TemporaryFolder(File("."))
+
     @Test
     fun basicPluginTest() {
-        val tmpDir = File(".", "build/testProject")
-        tmpDir.deleteRecursively()
+        val projectDir = temporaryFolder.newFolder("project")
+        File("src/test/testProject").copyRecursively(projectDir)
 
-        println(File(".").absolutePath)
-        File(".", "src/test/testProject").copyRecursively(tmpDir)
-
-        val result = GradleRunner.create().withProjectDir(tmpDir)
+        val result = GradleRunner.create().withProjectDir(projectDir)
                 .forwardStdOutput(System.out.writer())
                 .forwardStdError(System.err.writer())
                 .withArguments("generateSwagger")
                 .build()
 
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateSwagger")?.outcome)
+
+        val result2ndRun = GradleRunner.create().withProjectDir(projectDir)
+                .forwardStdOutput(System.out.writer())
+                .forwardStdError(System.err.writer())
+                .withArguments("generateSwagger")
+                .build()
+        Assert.assertEquals(TaskOutcome.UP_TO_DATE, result2ndRun.task(":generateSwagger")?.outcome)
     }
 }


### PR DESCRIPTION
The goal of this PR is to unify the creation of temporary directories of tests under the same approach (TemporaryFolder junit rule).
