### PR TITLE
Miscellaneous documentation update

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-make install-hooks
+./gradlew installVenv installHooks
 
 source venv/bin/activate

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Here you can find the release notes for this project. Please note that list of r
 * ⚙️ Gradle to 5.6.2 [#67]
 * ⚙️ Add JaCoCo for CodeCov [#66]
 
-⚠️: `swagger-gradle-codegen:plugin:1.3.0` is **NOT** supported on Gradle 5
+⚠️: `swagger-gradle-codegen:plugin:1.3.0` is supported **ONLY** on Gradle 6+
 
 Thanks to @cortinico @doug-precocity @redwarp @macisamuele @filipemp for the support with this release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Here you can find the release notes for this project. Please note that list of r
 * ⚙️ Gradle to 5.6.2 [#67]
 * ⚙️ Add JaCoCo for CodeCov [#66]
 
+⚠️: `swagger-gradle-codegen:plugin:1.3.0` is **NOT** supported on Gradle 5
+
 Thanks to @cortinico @doug-precocity @redwarp @macisamuele @filipemp for the support with this release
 
 ## v1.2.0 (2019-07-31)

--- a/README.md
+++ b/README.md
@@ -156,15 +156,15 @@ We also recommend you set up:
 Before starting developing, please run:
 
 ```
-make install-hooks
+./gradlew installHooks
 ```
 
 This will take care of installing the pre-commit hooks to keep a consistent style in the codebase.
 
-While developing, you can run tests on the plugin using:
+While developing, you can build, run pre-commits, checks & tests on the plugin using:
 
 ```
-./gradlew plugin:test
+./gradlew preMerge
 ```
 
 Make sure your tests are all green ✅ locally before submitting PRs.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
+# Remember to update the README.md file once the version is updated
+# Prevent https://github.com/Yelp/swagger-gradle-codegen/issues/108 to happen again
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The goal of this PR is:
 * highlight Gradle5 incompatibility of release 1.3.0
 * re-establish Gradle5+ support
 * remove all traces of `make ...` invocations (as Makefile was removed in #105 )

NOTE: Ideally we should be able to merge this once #108 troubleshooting is over.
Ideally, we should not drop support to gradle versions if we have no benefits on doing it