### PR TITLE
Add plugin tests against an older version of Gradle

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/yelp/codegen/plugin.gradle.kts
+++ b/gradle-plugin/plugin/src/main/kotlin/com/yelp/codegen/plugin.gradle.kts
@@ -2,8 +2,13 @@ package com.yelp.codegen
 
 import com.yelp.codegen.plugin.GenerateTask
 import com.yelp.codegen.plugin.GenerateTaskConfiguration
+import org.gradle.util.GradleVersion
 
 val config = extensions.create("generateSwagger", GenerateTaskConfiguration::class.java, project)
+
+require(GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0) {
+    "com.yelp.codegen.plugin requires Gradle version 5.0 or greater"
+}
 
 tasks {
     register<GenerateTask>("generateSwagger") {

--- a/gradle-plugin/plugin/src/main/kotlin/com/yelp/codegen/plugin.gradle.kts
+++ b/gradle-plugin/plugin/src/main/kotlin/com/yelp/codegen/plugin.gradle.kts
@@ -6,7 +6,7 @@ import org.gradle.util.GradleVersion
 
 val config = extensions.create("generateSwagger", GenerateTaskConfiguration::class.java, project)
 
-require(GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0) {
+require(GradleVersion.current() >= GradleVersion.version("5.0")) {
     "com.yelp.codegen.plugin requires Gradle version 5.0 or greater"
 }
 

--- a/gradle-plugin/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
+++ b/gradle-plugin/plugin/src/test/java/com/yelp/plugin/PluginTests.kt
@@ -32,4 +32,20 @@ class PluginTests {
                 .build()
         Assert.assertEquals(TaskOutcome.UP_TO_DATE, result2ndRun.task(":generateSwagger")?.outcome)
     }
+
+    @Test
+    fun testGradle5_4_1() {
+        val projectDir = temporaryFolder.newFolder("project")
+        File("src/test/testProject").copyRecursively(projectDir)
+
+        val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withGradleVersion("5.4.1")
+                .forwardStdOutput(System.out.writer())
+                .forwardStdError(System.err.writer())
+                .withArguments("generateSwagger")
+                .build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateSwagger")?.outcome)
+    }
 }


### PR DESCRIPTION
This is taken from https://github.com/Yelp/swagger-gradle-codegen/pull/112 but still keeping the `kotlin-dsl` plugin.