### PR TITLE
Add Action to validate the Gradle Wrapper

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: Validate Gradle Wrapper
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Let's add a Github Action to validate the Gradle wrapper.
~@macisamuele can you ask to enable Actions support for this repo?~ looks like is not needed 👍 