### PR TITLE
HeadersToRemove should apply also to top level headers

### DIFF
--- a/gradle-plugin/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
+++ b/gradle-plugin/plugin/src/main/java/com/yelp/codegen/KotlinGenerator.kt
@@ -431,13 +431,16 @@ open class KotlinGenerator : SharedCodegen() {
             }
         }
 
-        codegenOperation.imports.add("retrofit2.http.Headers")
-
         // Let's remove the leading
         if (!basePath.isNullOrBlank()) {
             codegenOperation.path = codegenOperation.path.removePrefix("/")
         }
+
+        // Let's process the top level Headers and eventually add the retrofit annotations.
         processTopLevelHeaders(codegenOperation)
+        if (codegenOperation.vendorExtensions[HAS_OPERATION_HEADERS] == true) {
+            codegenOperation.imports.add("retrofit2.http.Headers")
+        }
 
         // Let's make sure we import all the types, also the inner ones (see #76).
         codegenOperation.responses.forEach {
@@ -507,6 +510,10 @@ open class KotlinGenerator : SharedCodegen() {
                 topLevelHeaders.add(HEADER_CONTENT_TYPE to it)
             }
         }
+
+        // Process the
+        val headersToIgnore = getHeadersToIgnore()
+        topLevelHeaders.removeIf { it.first in headersToIgnore }
 
         operation.vendorExtensions[HAS_OPERATION_HEADERS] = topLevelHeaders.isNotEmpty()
         operation.vendorExtensions[OPERATION_HEADERS] = topLevelHeaders

--- a/gradle-plugin/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
+++ b/gradle-plugin/plugin/src/test/java/com/yelp/codegen/KotlinGeneratorTest.kt
@@ -380,6 +380,21 @@ class KotlinGeneratorTest {
     }
 
     @Test
+    fun processTopLevelHeaders_withOperationIdAndHeadersToIgnore_hasNoHeaders() {
+        val testOperationId = "aTestOperationId"
+        val generator = KotlinGenerator()
+        val operation = CodegenOperation()
+        generator.additionalProperties()[HEADERS_TO_IGNORE] = HEADER_X_OPERATION_ID
+        operation.vendorExtensions = mutableMapOf(X_OPERATION_ID to (testOperationId as Any))
+
+        generator.processTopLevelHeaders(operation)
+
+        assertEquals(false, operation.vendorExtensions["hasOperationHeaders"])
+        val headerMap = operation.vendorExtensions["operationHeaders"] as List<*>
+        assertEquals(0, headerMap.size)
+    }
+
+    @Test
     fun processTopLevelHeaders_withConsumes_hasContentTypeHeader() {
         val generator = KotlinGenerator()
         val operation = CodegenOperation()
@@ -396,6 +411,23 @@ class KotlinGeneratorTest {
         val firstPair = headerMap[0] as Pair<*, *>
         assertEquals(HEADER_CONTENT_TYPE, firstPair.first as String)
         assertEquals("application/json", firstPair.second as String)
+    }
+
+    @Test
+    fun processTopLevelHeaders_withConsumesAndHeadersToIgnore_hasNoContentTypeHeader() {
+        val generator = KotlinGenerator()
+        val operation = CodegenOperation()
+        generator.additionalProperties()[HEADERS_TO_IGNORE] = HEADER_CONTENT_TYPE
+        operation.vendorExtensions = mutableMapOf()
+        operation.consumes = listOf(
+                mapOf("mediaType" to "application/json")
+        )
+
+        generator.processTopLevelHeaders(operation)
+
+        assertEquals(false, operation.vendorExtensions["hasOperationHeaders"])
+        val headerMap = operation.vendorExtensions["operationHeaders"] as List<*>
+        assertEquals(0, headerMap.size)
     }
 
     @Test


### PR DESCRIPTION
Make sure we actually filter out also top level headers
and not only parameter headers with the `headersToRemove` feature.

Fixes #120