### PR TITLE
Update Gradle plugin-publish to 0.11.0

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     `maven-publish`
     jacoco
     kotlin("jvm") version "1.3.70"
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.11.0"
     id("io.gitlab.arturbosch.detekt") version "1.4.0"
 }
 


### PR DESCRIPTION
There is a security update for the `plugin-publish` Gradle Plugin:
https://blog.gradle.org/plugin-portal-update after a vulnerability was discovered.

This is mandatory as previous version of the plugin will stop working.