### PR TITLE
Small GH Actions optimizations

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,11 @@
 name: Validate Gradle Wrapper
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   validation:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,9 +1,16 @@
 name: Pre Merge Checks
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   gradle:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,11 +1,11 @@
 name: Pre Merge Checks
-on: 
+on:
   push:
     branches:
-      - master
+    - master
   pull_request:
     branches:
-      - '*'
+    - '*'
 
 jobs:
   gradle:


### PR DESCRIPTION
- Set `fail-fast` to false so we'll see the outcome of all the builds
- Trigger `push` only on `master` so we won't have duplicate builds