### PR TITLE
Bump io.swagger:swagger-codegen to 2.4.16

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     implementation("commons-cli:commons-cli:1.4")
     implementation("com.google.guava:guava:27.0-jre")
-    implementation("io.swagger:swagger-codegen:2.4.12")
+    implementation("io.swagger:swagger-codegen:2.4.16")
 
     testImplementation("junit:junit:4.12")
 }


### PR DESCRIPTION
As the title says.

The goal of this is to prepare a branch to address the addition of OpenAPI v3 (#51) and ideally we might (even if I doubt) reduce some conflicts.

Still bumping a dependency is not a bad idea, especially if tests continue to be green