### PR TITLE
Initialize optional query parameters with null

### DIFF
--- a/gradle-plugin/plugin/src/main/resources/kotlin/retrofit2/queryParams.mustache
+++ b/gradle-plugin/plugin/src/main/resources/kotlin/retrofit2/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}@retrofit2.http.Query("{{baseName}}") {{#collectionFormat}}{{^isCollectionFormatMulti}}@{{{collectionFormat.toUpperCase}}} {{/isCollectionFormatMulti}}{{/collectionFormat}}{{paramName}}: {{{dataType}}}{{/isQueryParam}}
+{{#isQueryParam}}@retrofit2.http.Query("{{baseName}}") {{#collectionFormat}}{{^isCollectionFormatMulti}}@{{{collectionFormat.toUpperCase}}} {{/isCollectionFormatMulti}}{{/collectionFormat}}{{paramName}}: {{{dataType}}}{{^required}} = null{{/required}}{{/isQueryParam}}

--- a/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
+++ b/samples/junit-tests/src/main/java/com/yelp/codegen/generatecodesamples/apis/ResourceApi.kt
@@ -116,11 +116,11 @@ interface ResourceApi {
     )
     @GET("/symbols/in/parameter/name")
     fun getSymbolsInParameterName(
-        @retrofit2.http.Query("parameter") parameter: String?,
-        @retrofit2.http.Query("brackets[]") brackets: String?,
-        @retrofit2.http.Query("brackets[withText]") bracketsWithText: String?,
-        @retrofit2.http.Query("dot.") dot: String?,
-        @retrofit2.http.Query("dot.withText") dotWithText: String?
+        @retrofit2.http.Query("parameter") parameter: String? = null,
+        @retrofit2.http.Query("brackets[]") brackets: String? = null,
+        @retrofit2.http.Query("brackets[withText]") bracketsWithText: String? = null,
+        @retrofit2.http.Query("dot.") dot: String? = null,
+        @retrofit2.http.Query("dot.withText") dotWithText: String? = null
     ): Completable
     /**
      * The endpoint is owned by junittests service owner

--- a/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/ValidParameterTest.kt
+++ b/samples/junit-tests/src/test/java/com/yelp/codegen/generatecodesamples/ValidParameterTest.kt
@@ -3,6 +3,7 @@ package com.yelp.codegen.generatecodesamples
 import com.yelp.codegen.generatecodesamples.apis.ResourceApi
 import com.yelp.codegen.generatecodesamples.tools.MockServerApiRule
 import okhttp3.mockwebserver.MockResponse
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -35,5 +36,23 @@ class ValidParameterTest {
         assertTrue("brackets%5BwithText%5D=testBracketsWithText" in requestPath)
         assertTrue("dot.=testDot" in requestPath)
         assertTrue("dot.withText=testDotWithText" in requestPath)
+    }
+
+    @Test
+    fun optionalParameters() {
+        mockServerRule.server.enqueue(MockResponse())
+
+        val defaultApi = mockServerRule.getApi<ResourceApi>()
+        val pet = defaultApi.getSymbolsInParameterName().blockingGet()
+
+        val requestPath = mockServerRule.server.takeRequest().path
+        assertNull(pet)
+
+        // No parameters should be present in the path
+        assertFalse("parameter=" in requestPath)
+        assertFalse("brackets%5B%5D=" in requestPath)
+        assertFalse("brackets%5BwithText%5D=" in requestPath)
+        assertFalse("dot.=" in requestPath)
+        assertFalse("dot.withText=" in requestPath)
     }
 }


### PR DESCRIPTION
Pretty self explanatory, helps with calling APIs with many parameters as you don't have to specify all params.

_Considered also initialising with default value but that's more like the value the server assigns when a param is missing so I don't think it's wise to pre-initialize it in the client._