### PR TITLE
Swagger Codegen to 2.4.21

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -27,7 +27,13 @@ dependencies {
     implementation(gradleApi())
 
     implementation("commons-cli:commons-cli:1.4")
-    implementation("io.swagger:swagger-codegen:2.4.16")
+    implementation("com.google.guava:guava") {
+        version {
+            // We force the version otherwise we get a -android version that will break when used with AGP.
+            strictly("28.2-jre")
+        }
+    }
+    implementation("io.swagger:swagger-codegen:2.4.21")
 
     testImplementation("junit:junit:4.13.2")
 }


### PR DESCRIPTION
Bumping `swagger-codegen` to the latest stable in the 2.x series.